### PR TITLE
Add support for Chef Target Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.2.0
+
+- Add support for being used in Chef Target Mode as well
+
 ## Version 0.1.0
 
 - Initial version

--- a/README.md
+++ b/README.md
@@ -140,3 +140,35 @@ conn   = train.connection
 # Handles logout as well
 conn.close
 ```
+
+## Use with Redfish, Your Custom Resources and Chef Target Mode
+
+1. Set up a credentials file under `~/.chef/credentials` or `/etc/chef/credentials`:
+
+   ```toml
+   ['10.0.0.1']
+   endpoint = 'https://10.0.0.1/redfish/v1/'
+   username = 'user'
+   password = 'pass'
+   verify_ssl = false
+   auth_type = 'redfish'
+   ```
+
+1. Configure Chef to use the REST transport in `client.rb`:
+
+   ```toml
+   target_mode.protocol = "rest"
+   ```
+
+1. Write your custom resources for REST APIs
+1. Mark them up using the REST methods for target mode:
+
+   ```ruby
+   provides :rest_resource, target_mode: true, platform: 'rest'
+   ```
+
+1. Run against the defiend targets via Chef Target Mode:
+
+   ```shell
+   chef-client --local-mode --target 10.0.0.1 --runlist 'recipe[my-cookbook:setup]'
+   ```

--- a/lib/train-rest/connection.rb
+++ b/lib/train-rest/connection.rb
@@ -30,8 +30,24 @@ module TrainPlugins
         components.to_s
       end
 
+      def inventory
+        # Faking it for Chef Target Mode only
+        OpenStruct.new({
+          name: "rest",
+          release: TrainPlugins::Rest::VERSION,
+          family_hierarchy: ["", "api"],
+          family: "api",
+          platform: "rest",
+          platform_version: 0,
+        })
+      end
+
+      alias os inventory
+
       def platform
-        force_platform!("rest", { endpoint: uri })
+        Train::Platforms.name("rest").in_family("api")
+
+        force_platform!("rest", { release: TrainPlugins::Rest::VERSION })
       end
 
       # User-faced API
@@ -100,7 +116,7 @@ module TrainPlugins
       end
 
       def auth_type
-        return options[:auth_type] if options[:auth_type]
+        return options[:auth_type].to_sym if options[:auth_type]
 
         :basic if options[:username] && options[:password]
       end

--- a/lib/train-rest/version.rb
+++ b/lib/train-rest/version.rb
@@ -1,5 +1,5 @@
 module TrainPlugins
   module Rest
-    VERSION = "0.1.0".freeze
+    VERSION = "0.2.0".freeze
   end
 end


### PR DESCRIPTION
Add some workaround to be usable in Chef Target Mode to write custom REST resources.

Chef currently involuntarily triggers Train's platform detection which can only handle line-protocols like SSH. To avoid this, the `os` method of this platform is now mocking a regular platform.

Chef also does not support Symbols in the credentials file yet. So the plugin will accept both string and symbol for `auth_type` now.

Please remember that Target Mode is highly experimental and not a stable API.