### PR TITLE
Add ability to fake remote endpoints via VCR; Fix documentation for SSL verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.3.0
+
+- Add VCR options for mocking API responses in development/test
+
 ## Version 0.2.1
 
 - Fix RedFish handler for bare (non-prefixed) URLs

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ rake install:local
 | Option               | Explanation                             | Default     |
 | -------------------- | --------------------------------------- | ----------- |
 | `endpoint`           | Endpoint of the REST API                | _required_  |
-| `validate_ssl`       | Check certificate and chain             | true        |
+| `verify_ssl`         | Check certificate and chain             | true        |
 | `auth_type`          | Authentication type                     | `anonymous` |
 | `debug_rest`         | Enable debugging of HTTP traffic        | false       |
 | `logger`             | Alternative logging class               |             |
@@ -166,7 +166,7 @@ require 'train-rest'
 # This will immediately do a login and add headers
 train  = Train.create('rest', {
             endpoint: 'https://10.20.30.40',
-            validate_ssl: false,
+            verify_ssl: false,
 
             auth_type: :redfish,
             username: 'iloadmin',
@@ -209,5 +209,28 @@ conn.close
 1. Run against the defiend targets via Chef Target Mode:
 
    ```shell
-   chef-client --local-mode --target 10.0.0.1 --runlist 'recipe[my-cookbook:setup]'
+   chef-client --local-mode --target 10.0.0.1 --runlist 'recipe[my-cookbook::setup]'
    ```
+
+## Use with Prerecorded API responses
+
+For testing during and after development, not all APIs can be used to verify your solution against.
+The VCR gem offers the possibility to hook into web requests and intercept them to play back canned
+responses.
+
+Please read the documentation of the VCR gem on how to record your API and the concepts like
+"cassettes", "libraries" and matchers.
+
+The following options are available in train-rest for this:
+
+| Option               | Explanation                             | Default      |
+| -------------------- | --------------------------------------- | ------------ |
+| `vcr_cassette`       | Name of the response file               | nil          |
+| `vcr_library`        | Directory to search responses in        | `vcr`        |
+| `vcr_match_on`       | Elements to match request by            | `method uri` |
+| `vcr_record`         | Recording mode                          | `none`       |
+| `vcr_hook_into`      | Base library for intercepting           | `webmock`    |
+
+VCR will only be required as a Gem and activated, if you supply a cassette name.
+
+You can use all these settings in your Chef Target Mode `credentials` file as well.

--- a/lib/train-rest/transport.rb
+++ b/lib/train-rest/transport.rb
@@ -1,3 +1,5 @@
+require "rubygems"
+
 require "train-rest/connection"
 
 module TrainPlugins
@@ -16,8 +18,31 @@ module TrainPlugins
       option :password, default: nil
       option :debug_rest, default: false
 
+      option :vcr_cassette, default: nil
+      option :vcr_library, default: "vcr"
+      option :vcr_match_on, default: "method uri"
+      option :vcr_record, default: "none"
+      option :vcr_hook_into, default: "webmock"
+
       def connection(_instance_opts = nil)
+        dependency_checks
+
         @connection ||= TrainPlugins::Rest::Connection.new(@options)
+      end
+
+      private
+
+      def dependency_checks
+        return unless @options[:vcr_cassette]
+
+        raise Gem::LoadError.new("Install VCR Gem for API playback capability") unless gem_installed?("vcr")
+
+        stubber = @options[:vcr_hook_into]
+        raise Gem::LoadError.new("Install #{stubber} Gem for API playback capability") unless gem_installed?(stubber)
+      end
+
+      def gem_installed?(name)
+        Gem::Specification.find_all_by_name(name).any?
       end
     end
   end

--- a/lib/train-rest/version.rb
+++ b/lib/train-rest/version.rb
@@ -1,5 +1,5 @@
 module TrainPlugins
   module Rest
-    VERSION = "0.2.1".freeze
+    VERSION = "0.3.0".freeze
   end
 end


### PR DESCRIPTION
For developing with remote APIs, it is often beneficial to be able to use canned responses. This PR integrates the VCR gem to allow quicker development/testing.