### PR TITLE
Fix patch/post/put shortcut methods for keyword arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.3.2
+
+- Fix `patch`, `post` and `put` methods to accept keyword arguments properly
+
 ## Version 0.3.1
 
 - Fix basic authentication

--- a/lib/train-rest/connection.rb
+++ b/lib/train-rest/connection.rb
@@ -87,9 +87,8 @@ module TrainPlugins
       # User-faced API
 
       %i{get post put patch delete head}.each do |method|
-        define_method(method) do |path, *parameters|
-          # TODO: "warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call"
-          request(path, method, *parameters)
+        define_method(method) do |path, **keywords|
+          request(path, method, **keywords)
         end
       end
 

--- a/lib/train-rest/version.rb
+++ b/lib/train-rest/version.rb
@@ -1,5 +1,5 @@
 module TrainPlugins
   module Rest
-    VERSION = "0.3.1".freeze
+    VERSION = "0.3.2".freeze
   end
 end


### PR DESCRIPTION
These three dynamically generated shortcut methods did not play nice with keyword arguments, resulting in messages like `ArgumentError: wrong number of arguments (given 3, expected 1..2)`